### PR TITLE
FIX : 1.0 flag to prevent hook being applied twice on object

### DIFF
--- a/class/actions_deliveryaddress.class.php
+++ b/class/actions_deliveryaddress.class.php
@@ -178,7 +178,9 @@ class ActionsDeliveryAddress
 			}
 
 			// Gestion des sauts de lignes si la note était en HTML de base
-			$object->note_public_original = $object->note_public;
+			if (!isset($object->note_public_original)) {
+				$object->note_public_original = $object->note_public;
+			}
 			if($wysiwyg) $object->note_public = dol_nl2br($txt).$object->note_public;
 			else $object->note_public = $txt.$object->note_public;
 		}

--- a/class/actions_deliveryaddress.class.php
+++ b/class/actions_deliveryaddress.class.php
@@ -69,7 +69,6 @@ class ActionsDeliveryAddress
 			|| 	(in_array('ordersuppliercard',explode(':',$parameters['context'])) && empty($conf->global->DELIVERYADDRESS_HIDE_ADDRESS_ON_ORDERSUPPLIERCARD))
 			)
 		{
-			if (!empty($object->flag_delivery_address_in_public_note)) return 0;
 			$outputlangs = $parameters['outputlangs'];
 			$outputlangs->load('deliveryaddress@deliveryaddress');
 
@@ -179,9 +178,25 @@ class ActionsDeliveryAddress
 			}
 
 			// Gestion des sauts de lignes si la note était en HTML de base
+			$object->note_public_original = $object->note_public;
 			if($wysiwyg) $object->note_public = dol_nl2br($txt).$object->note_public;
 			else $object->note_public = $txt.$object->note_public;
-			$object->flag_delivery_address_in_public_note = true;
 		}
+	}
+
+	/**
+	 * @param array        $parameters
+	 * @param CommonObject $object
+	 * @param string       $action
+	 * @param HookManager  $hookmanager
+	 */
+	function afterPDFCreation($parameters, &$object, &$action, $hookmanager)
+	{
+		// clean up the object if it was altered by beforePDFCreation
+		$object = $parameters['object'];
+		if (isset($object->note_public_original)) {
+			$object->note_public = $object->note_public_original;
+		}
+		return 0;
 	}
 }

--- a/class/actions_deliveryaddress.class.php
+++ b/class/actions_deliveryaddress.class.php
@@ -68,14 +68,15 @@ class ActionsDeliveryAddress
 			)
 		{
 			global $db, $user, $conf, $mysoc;
+			if (!empty($object->flag_delivery_address_in_public_note)) return 0;
 			$outputlangs = $parameters['outputlangs'];
 			$outputlangs->load('deliveryaddress@deliveryaddress');
-			
+
 			dol_include_once('/contact/class/contact.class.php');
 			dol_include_once('/core/lib/pdf.lib.php');
 			$wysiwyg = !empty($conf->fckeditor->enabled);
 			$txt = '';
-			
+
 			$TContacts = array();
 			if(method_exists($object, 'liste_contact')) $TContacts = $object->liste_contact();
 			foreach($TContacts as $c) {
@@ -84,8 +85,8 @@ class ActionsDeliveryAddress
 					$contact->fetch($c['id']);
 					$soc = new Societe($db);
 					$soc->fetch($c['socid']);
-					
-					
+
+
 
 					$title = $outputlangs->trans("DeliveryAddress")." :\n";
 					$socname = !empty($contact->socname) ? $contact->socname."\n" : "";
@@ -97,7 +98,7 @@ class ActionsDeliveryAddress
 					$address = pdf_build_address($outputlangs, $mysoc, $soc, $contact, 1, 'target');
 					$conf->global->MAIN_TVAINTRA_NOT_IN_ADDRESS = $maconfTVA;
 					$conf->global->MAIN_PDF_ADDALSOTARGETDETAILS = $maconfTargetDetails;
-					
+
 					$phone = '';
 					if(!empty($conf->global->DELIVERYADDRESS_SHOW_PHONE)) {
 						if (! empty($contact->phone_pro) || ! empty($contact->phone_mobile)) $phone .= ($address ? "\n" : '' ).$outputlangs->transnoentities("Phone").": ";
@@ -106,13 +107,13 @@ class ActionsDeliveryAddress
 						if (! empty($contact->phone_mobile)) $phone .= $outputlangs->convToOutputCharset($contact->phone_mobile);
 					}
 					$end = !empty($object->note_public) ? "\n" : "";
-					
+
 					$txt = $title . $socname . $address . $phone . $end;
-					
+
 					break;
 				}
 			}
-			
+
 			if (!empty($conf->global->DELIVERYADDRESS_SHOW_INFO_REPONSABLE_RECEPTION))
 			{
 				$TContacts = array();
@@ -130,24 +131,25 @@ class ActionsDeliveryAddress
 						$title = $outputlangs->trans("ReceiptContact")." :\n";
 						$name = dolGetFirstLastname($u->firstname, $u->lastname)."\n";
 						if($wysiwyg) $name = '<strong>'.$name.'</strong>';
-						
+
 						$phone = $outputlangs->transnoentities("Phone").': ';
 						if (!empty($u->office_phone)) $phone.= $u->office_phone;
 						if (!empty($u->office_phone) && !empty($u->user_mobile)) $phone.= ' / '.$u->user_mobile;
 						else if (!empty($u->user_mobile)) $phone .= $u->user_mobile;
-						
+
 						$end = !empty($object->note_public) ? "\n" : "";
-						
+
 						$txt.= $title . $name . $phone . $end;
-						
+
 						break;
 					}
 				}
 			}
-			
+
 			// Gestion des sauts de lignes si la note était en HTML de base
 			if($wysiwyg) $object->note_public = dol_nl2br($txt).$object->note_public;
 			else $object->note_public = $txt.$object->note_public;
+			$object->flag_delivery_address_in_public_note = true;
 		}
 	}
 }

--- a/core/modules/modDeliveryAddress.class.php
+++ b/core/modules/modDeliveryAddress.class.php
@@ -59,7 +59,7 @@ class modDeliveryAddress extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module DeliveryAddress";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.3';
+		$this->version = '1.3.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
- FIX : When a process creates 2 (or more) PDFs for the same document, the delivery address is prepended to the public note of the document twice (or more) by `beforePDFCreation`.

   This PR adds a flag on `$object` to ensure the address only gets added once.